### PR TITLE
Add smoke test task

### DIFF
--- a/ci/smoke_test.sh
+++ b/ci/smoke_test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+apt-get update
+apt-get install curl
+
+curl -qf "${TARGET_URL}"

--- a/ci/smoke_tests.yml
+++ b/ci/smoke_tests.yml
@@ -1,0 +1,13 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: ubuntu
+
+inputs:
+- name: ras-rm-metrics-source
+
+run:
+  path: ras-rm-metrics-source/ci/smoke_tests.sh


### PR DESCRIPTION
This will add a smoke test task to be used by the ci server to check
that the application has been successfully deployed.